### PR TITLE
added pages for forgot password, reset password and updated login page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import NewFeature from './pages/NewFeature.jsx';
 import BlogList from './components/ui/BlogSection.jsx';
 import BlogDetail from './components/ui/BlogDetail.jsx';
 import AddBlog from './components/ui/AddBlog.jsx';
+import ForgotPassword from './pages/ForgotPassword.jsx';
+import ResetPassword from './pages/ResetPassword.jsx';
 const App = () => {
     return (
         <>
@@ -30,6 +32,8 @@ const App = () => {
                 <Route index element={<Index/>} />
                 <Route path ="signup" element={<Signup/>} />
                 <Route path ="login" element={<Login/>} />
+                <Route path ="forgot-password" element={<ForgotPassword/>} />
+                <Route path ="reset-password/:token" element={<ResetPassword/>} />
                 <Route  path ="feed" element={<Feed/>} />
                 <Route path ="connections" element={<Connections/>} />
                 <Route path ="requests" element={<Requests/>} />

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react';
+import { Mail, ArrowLeft, KeyRound } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { createApiUrl, API_ENDPOINTS } from '../utils/apiConfig';
+import {
+    AuthLayout,
+    AuthLogo,
+    AuthHeader,
+    InputField,
+    SubmitButton
+} from '../components';
+
+const ForgotPassword = () => {
+    const [emailId, setEmail] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [message, setMessage] = useState('');
+    const [error, setError] = useState('');
+    const [otp, setOtp] = useState('');
+    const [otpSent, setOtpSent] = useState(false);
+    const [verifying, setVerifying] = useState(false);
+    const navigate = useNavigate();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        if (!emailId.trim()) {
+            setError('Please enter your email address');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+        setMessage('');
+
+        try {
+            const response = await axios.post(
+                createApiUrl(API_ENDPOINTS.FORGOT_PASSWORD),
+                { emailId: emailId.trim() }
+            );
+            setMessage(response.data.message);
+            setOtpSent(true);
+        } catch (err) {
+            console.error('Forgot password error:', err);
+            setError(err.response?.data?.message || 'Something went wrong. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleVerifyOtp = async (e) => {
+        e.preventDefault();
+        if (!otp.trim()) {
+            setError('Please enter the OTP sent to your email');
+            return;
+        }
+        setError('');
+        setVerifying(true);
+        try {
+            const response = await axios.post(
+                createApiUrl(API_ENDPOINTS.VERIFY_OTP),
+                { emailId: emailId.trim(), otp: otp.trim() }
+            );
+            const token = response.data?.resetToken;
+            if (token) {
+                navigate(`/reset-password/${token}`);
+            } else {
+                setError('Verification failed. Please try again.');
+            }
+        } catch (err) {
+            console.error('Verify OTP error:', err);
+            setError(err.response?.data?.message || 'Invalid OTP. Please try again.');
+        } finally {
+            setVerifying(false);
+        }
+    };
+
+    return (
+        <AuthLayout>
+            <AuthLogo />
+            
+            <div className="text-center mb-6">
+                <Link 
+                    to="/login" 
+                    className="inline-flex items-center text-gray-400 hover:text-white transition-colors"
+                >
+                    <ArrowLeft className="w-4 h-4 mr-2" />
+                    Back to Login
+                </Link>
+            </div>
+
+            <AuthHeader
+                title={otpSent ? 'Enter Verification Code' : 'Forgot Password?'}
+                subtitle={
+                    otpSent
+                        ? `We sent a 6-digit code to ${emailId}. Enter it below to continue.`
+                        : "Enter your email and we'll send you a verification code"
+                }
+            />
+
+            {!otpSent ? (
+            <form onSubmit={handleSubmit} className="space-y-4">
+                {error && (
+                    <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-lg text-center">
+                        {error}
+                    </div>
+                )}
+
+                {message && (
+                    <div className="bg-green-500/10 border border-green-500/20 text-green-400 px-4 py-3 rounded-lg text-center">
+                        {message}
+                    </div>
+                )}
+
+                <InputField
+                    value={emailId}
+                    onChange={(e) => setEmail(e.target.value)}
+                    type="email"
+                    placeholder="Enter your email address"
+                    icon={Mail}
+                    required
+                />
+
+                <SubmitButton 
+                    type="submit" 
+                    text={loading ? "Sending..." : "Send Code"}
+                    disabled={loading}
+                />
+            </form>
+            ) : (
+            <form onSubmit={handleVerifyOtp} className="space-y-4">
+                {error && (
+                    <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-lg text-center">
+                        {error}
+                    </div>
+                )}
+
+                {message && (
+                    <div className="bg-green-500/10 border border-green-500/20 text-green-400 px-4 py-3 rounded-lg text-center">
+                        {message}
+                    </div>
+                )}
+
+                <InputField
+                    value={otp}
+                    onChange={(e) => setOtp(e.target.value)}
+                    type="text"
+                    placeholder="Enter 6-digit code"
+                    icon={KeyRound}
+                    required
+                />
+
+                <SubmitButton 
+                    type="submit" 
+                    text={verifying ? "Verifying..." : "Verify Code"}
+                    disabled={verifying}
+                />
+            </form>
+            )}
+
+            <div className="text-center text-gray-400 text-sm mt-6">
+                Remember your password?{' '}
+                <Link to="/login" className="text-[#ff512f] hover:underline">
+                    Log in
+                </Link>
+            </div>
+
+            <div className="text-center text-gray-500 text-xs mt-4">
+                {otpSent ? (
+                    <>
+                        <p>Enter the code we sent to your email. It expires in 10 minutes.</p>
+                        <p>Didn't receive it? Check spam or request a new code.</p>
+                    </>
+                ) : (
+                    <>
+                        <p>We will send a 6-digit verification code to your email.</p>
+                        <p>The code expires in 10 minutes for security.</p>
+                    </>
+                )}
+            </div>
+        </AuthLayout>
+    );
+};
+
+export default ForgotPassword; 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Mail, Lock } from 'lucide-react';
 import { FaEye, FaEyeSlash } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 import {
     AuthLayout,
     AuthLogo,
@@ -93,9 +94,9 @@ const Login = () => {
                         <input type="checkbox" className="w-4 h-4 accent-[#ff512f]" />
                         <span>Remember me</span>
                     </div>
-                    <a href="/forgot-password" className="text-[#ff512f] hover:underline">
+                    <Link to="/forgot-password" className="text-[#ff512f] hover:underline">
                         Forgot password?
-                    </a>
+                    </Link>
                 </div>
 
                 <SubmitButton type="submit" text="Log In" />
@@ -103,9 +104,9 @@ const Login = () => {
 
             <div className="text-center text-gray-400 text-sm">
                 Don't have an account?{' '}
-                <a href="/signup" className="text-[#ff512f] hover:underline">
+                <Link to="/signup" className="text-[#ff512f] hover:underline">
                     Sign up
-                </a>
+                </Link>
             </div>
         </AuthLayout>
     );

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,210 @@
+import React, { useState, useEffect } from 'react';
+import { Lock, Eye, EyeOff, CheckCircle } from 'lucide-react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
+import { createApiUrl, API_ENDPOINTS } from '../utils/apiConfig';
+import {
+    AuthLayout,
+    AuthLogo,
+    AuthHeader,
+    InputField,
+    SubmitButton
+} from '../components';
+
+const ResetPassword = () => {
+    const { token } = useParams();
+    const navigate = useNavigate();
+    
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirm, setShowConfirm] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+
+    // Password strength indicators
+    const [passwordChecks, setPasswordChecks] = useState({
+        length: false,
+        uppercase: false,
+        lowercase: false,
+        number: false,
+        special: false
+    });
+
+    useEffect(() => {
+        if (!token) {
+            setError('Invalid reset link');
+            return;
+        }
+        
+        // Check password strength
+        const checks = {
+            length: newPassword.length >= 8,
+            uppercase: /[A-Z]/.test(newPassword),
+            lowercase: /[a-z]/.test(newPassword),
+            number: /\d/.test(newPassword),
+            special: /[!@#$%^&*(),.?":{}|<>]/.test(newPassword)
+        };
+        setPasswordChecks(checks);
+    }, [newPassword, token]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        
+        if (newPassword !== confirmPassword) {
+            setError('Passwords do not match');
+            return;
+        }
+
+        if (!Object.values(passwordChecks).every(Boolean)) {
+            setError('Please ensure your password meets all requirements');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+
+        try {
+            const response = await axios.post(
+                createApiUrl(API_ENDPOINTS.RESET_PASSWORD(token)),
+                { newPassword }
+            );
+            
+            setSuccess(true);
+            setNewPassword('');
+            setConfirmPassword('');
+            
+            // Redirect to login after 3 seconds
+            setTimeout(() => {
+                navigate('/login');
+            }, 3000);
+            
+        } catch (err) {
+            console.error('Reset password error:', err);
+            setError(err.response?.data?.message || 'Something went wrong. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    if (success) {
+        return (
+            <AuthLayout>
+                <AuthLogo />
+                <div className="text-center">
+                    <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+                    <h1 className="text-2xl font-bold text-white mb-2">Password Reset Successful!</h1>
+                    <p className="text-gray-400 mb-6">
+                        Your password has been updated. You will be redirected to the login page shortly.
+                    </p>
+                    <Link 
+                        to="/login"
+                        className="text-[#ff512f] hover:underline"
+                    >
+                        Go to Login Now
+                    </Link>
+                </div>
+            </AuthLayout>
+        );
+    }
+
+    return (
+        <AuthLayout>
+            <AuthLogo />
+            
+            <AuthHeader
+                title="Reset Your Password"
+                subtitle="Enter your new password below"
+            />
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                {error && (
+                    <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-lg text-center">
+                        {error}
+                    </div>
+                )}
+
+                <div className="space-y-4">
+                    <div className="relative">
+                        <InputField
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            type={showPassword ? 'text' : 'password'}
+                            placeholder="New Password"
+                            icon={Lock}
+                            required
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowPassword(!showPassword)}
+                            className="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white"
+                        >
+                            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                    </div>
+
+                    <div className="relative">
+                        <InputField
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            type={showConfirm ? 'text' : 'password'}
+                            placeholder="Confirm New Password"
+                            icon={Lock}
+                            required
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowConfirm(!showConfirm)}
+                            className="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white"
+                        >
+                            {showConfirm ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                    </div>
+                </div>
+
+                {/* Password Strength Indicator */}
+                <div className="bg-gray-800/50 rounded-lg p-4 space-y-2">
+                    <p className="text-sm text-gray-300 font-medium">Password Requirements:</p>
+                    <div className="space-y-1">
+                        <div className={`flex items-center text-sm ${passwordChecks.length ? 'text-green-400' : 'text-gray-500'}`}>
+                            <CheckCircle className={`w-4 h-4 mr-2 ${passwordChecks.length ? 'text-green-400' : 'text-gray-500'}`} />
+                            At least 8 characters
+                        </div>
+                        <div className={`flex items-center text-sm ${passwordChecks.uppercase ? 'text-green-400' : 'text-gray-500'}`}>
+                            <CheckCircle className={`w-4 h-4 mr-2 ${passwordChecks.uppercase ? 'text-green-400' : 'text-gray-500'}`} />
+                            One uppercase letter
+                        </div>
+                        <div className={`flex items-center text-sm ${passwordChecks.lowercase ? 'text-green-400' : 'text-gray-500'}`}>
+                            <CheckCircle className={`w-4 h-4 mr-2 ${passwordChecks.lowercase ? 'text-green-400' : 'text-gray-500'}`} />
+                            One lowercase letter
+                        </div>
+                        <div className={`flex items-center text-sm ${passwordChecks.number ? 'text-green-400' : 'text-gray-500'}`}>
+                            <CheckCircle className={`w-4 h-4 mr-2 ${passwordChecks.number ? 'text-green-400' : 'text-gray-500'}`} />
+                            One number
+                        </div>
+                        <div className={`flex items-center text-sm ${passwordChecks.special ? 'text-green-400' : 'text-gray-500'}`}>
+                            <CheckCircle className={`w-4 h-4 mr-2 ${passwordChecks.special ? 'text-green-400' : 'text-gray-500'}`} />
+                            One special character
+                        </div>
+                    </div>
+                </div>
+
+                <SubmitButton 
+                    type="submit" 
+                    text={loading ? "Updating Password..." : "Update Password"}
+                    disabled={loading || !Object.values(passwordChecks).every(Boolean)}
+                />
+            </form>
+
+            <div className="text-center text-gray-400 text-sm mt-6">
+                Remember your password?{' '}
+                <Link to="/login" className="text-[#ff512f] hover:underline">
+                    Log in
+                </Link>
+            </div>
+        </AuthLayout>
+    );
+};
+
+export default ResetPassword; 

--- a/src/utils/apiConfig.js
+++ b/src/utils/apiConfig.js
@@ -1,5 +1,5 @@
 // API configuration and base URL
-export const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:7777';
+export const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:3000';
 
 // API endpoints
 export const API_ENDPOINTS = {
@@ -22,6 +22,11 @@ export const API_ENDPOINTS = {
   // User endpoints
   USER_CONNECTIONS: '/user/connections',
   USER_REQUESTS_RECEIVED: '/user/requests/received',
+  
+  // Password reset endpoints
+  FORGOT_PASSWORD: '/auth/password/forgot',
+  VERIFY_OTP: '/auth/password/verify-otp',
+  RESET_PASSWORD: (token) => `/auth/password/reset/${token}`,
 };
 
 // Helper function to create full API URL


### PR DESCRIPTION
Summary
This PR corrects the forgot password feature, which previously behaved like a change password flow. The updated implementation introduces an OTP verification step for better security and UX. OTPs are sent via email using Nodemailer, and the frontend UI has been updated to support the new flow.

What’s Changed

Backend

Fixed forgot password route logic to send OTP instead of directly updating password.

Integrated Nodemailer to send OTP emails to registered users.

Added OTP verification endpoint before allowing password reset.

Frontend

src/pages/ForgotPassword.jsx:

Updated UI to collect OTP after email submission.

Added API call to verify OTP before navigating to reset password form.

Shows status messages and handles error cases (invalid/expired/missing OTP).

src/utils/apiConfig.js: Added VERIFY_OTP endpoint.



How to Test

Navigate to /forgot-password.

Enter a registered email → click Send Code.

Check email for OTP (sent via Nodemailer).

Enter OTP in the app:

Correct OTP → navigates to /reset-password/:token.

 Incorrect / expired / missing OTP → shows error message.

Set a new password → verify success.

